### PR TITLE
X11: Tweaking the forked process

### DIFF
--- a/Clipboard.cabal
+++ b/Clipboard.cabal
@@ -47,4 +47,5 @@ Library
                   , X11 == 1.6.*
                   , utf8-string
                   , unix
+                  , directory
     Other-modules:  System.Clipboard.X11

--- a/System/Clipboard/X11.hs
+++ b/System/Clipboard/X11.hs
@@ -11,6 +11,7 @@ import Data.Maybe
 import Data.Functor
 import Control.Monad
 import System.IO (hClose, stdin, stdout, stderr)
+import System.Directory (setCurrentDirectory)
 import Foreign.C.Types (CChar, CUChar)
 import Foreign.Marshal.Array (withArrayLen)
 import Codec.Binary.UTF8.String (decode, encode)
@@ -44,6 +45,7 @@ setClipboardString str = do
         hClose stdin
         hClose stdout
         hClose stderr
+        setCurrentDirectory "/"
         clipboardOutputWait display $ stringToChars str
         cleanup display window
 

--- a/System/Clipboard/X11.hs
+++ b/System/Clipboard/X11.hs
@@ -10,6 +10,7 @@ import System.Posix.Process (forkProcess)
 import Data.Maybe
 import Data.Functor
 import Control.Monad
+import System.IO (hClose, stdin, stdout, stderr)
 import Foreign.C.Types (CChar, CUChar)
 import Foreign.Marshal.Array (withArrayLen)
 import Codec.Binary.UTF8.String (decode, encode)
@@ -35,6 +36,9 @@ charsToString = decode . map fromIntegral
 setClipboardString :: String -> IO ()
 setClipboardString str = void $ forkProcess $
     withInitialSetup $ \display window clipboard -> do
+        hClose stdin
+        hClose stdout
+        hClose stderr
         xSetSelectionOwner display clipboard window currentTime
         clipboardOutputWait display $ stringToChars str
 


### PR DESCRIPTION
a41fa06: Fixes #4 

b670593: Run the initial setup outside of the forked process so the main process can receive X11 errors

127a499: Change directory to "/" in the forked process just in case the current directory needs to be unmounted