### PR TITLE
X11: setClipboardString copy the selection into the primary clipboard

### DIFF
--- a/System/Clipboard/X11.hs
+++ b/System/Clipboard/X11.hs
@@ -91,7 +91,7 @@ initialSetup = do
     display <- openDisplay ""
     window <- createSimpleWindow display (defaultRootWindow display)
                                  0 0 1 1 0 0 0
-    clipboards <- internAtom display "CLIPBOARD" True
+    clipboards <- internAtom display "CLIPBOARD" False
     return (display, window, [clipboards, pRIMARY])
 
 cleanup :: Display -> Window -> IO ()


### PR DESCRIPTION
X11 has multiple buffer for selection.
it use PRIMARY for highlighted text and CLIPBOARD for copied text.
This pull request aimed to synchronize those two buffer when we use setClipboardString
