### PR TITLE
X11: Use `SelectionClear` event from X11-1.8

### DIFF
--- a/Clipboard.cabal
+++ b/Clipboard.cabal
@@ -48,7 +48,7 @@ Library
     Other-modules:  System.Clipboard.Windows
   else
     Build-depends:  base == 4.*
-                  , X11 >= 1.6
+                  , X11 >= 1.8
                   , utf8-string
                   , unix
                   , directory

--- a/System/Clipboard/X11.hs
+++ b/System/Clipboard/X11.hs
@@ -13,7 +13,6 @@ import System.Posix.Process     (forkProcess)
 import Codec.Binary.UTF8.String (decode, encode)
 import Control.Monad
 import Data.Maybe
-import Foreign                  (peekByteOff)
 import Foreign.C.Types          (CChar, CUChar)
 import Foreign.Marshal.Array    (withArrayLen)
 import System.Directory         (setCurrentDirectory)
@@ -68,9 +67,7 @@ advertiseSelection display clipboards' str = allocaXEvent (go clipboards')
               sendSelectionNotify display ev_requestor ev_selection ev_target res ev_time
               go clipboards evPtr
 
-          _ | ev_event_type ev == selectionClear -> do
-              target <- peekByteOff evPtr 40 :: IO Atom
-              go (filter (/= target) clipboards) evPtr
+          SelectionClear {..} -> go (filter (/= ev_selection) clipboards) evPtr
 
           _ -> go clipboards evPtr
 


### PR DESCRIPTION
A fairly minor change. Now that xmonad/X11#48 has merged and is in X11-1.8, the `SelectionClear` event can be used.